### PR TITLE
Multi-target .net dependencies explicitly per target, and add net8 support

### DIFF
--- a/ids-lib.codegen/ids-lib.codegen.csproj
+++ b/ids-lib.codegen/ids-lib.codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>IdsLib.codegen</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/ids-lib/ids-lib.csproj
+++ b/ids-lib/ids-lib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
 		<RootNamespace>IdsLib</RootNamespace>
 		<Nullable>enable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -59,13 +59,25 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Nullable" Version="1.3.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
-  <!-- 
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+	</ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+	<!-- 
 	the following two targets tag the "product version" with version and commit hash 
 	such information is visible in the dll proprty information dialog.
   

--- a/ids-tool.tests/ids-tool.tests.csproj
+++ b/ids-tool.tests/ids-tool.tests.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
 		<IsPublishable>false</IsPublishable>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>idsTool.tests</RootNamespace>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>


### PR DESCRIPTION
Rationale: net6 target was depending on Logging.Abstractions v7.0.0 which creates issues in environments like azure functions when there are major version discrepancies.

Because ids-lib under net6 was referencing 7.0.0 logging abstractions while other libraries in a net6 app required 6.0.0 this was creating issues for us (e.g. xbim Geometry is targeting net6 and using 6.0.0 logging). While 7.0.0 is interface compatible with 6 some cases exist where it cause issues resolving an appropriate version, so I've split the ids-lib .net framework targeting explicitly for netstandard2, net6, and I've added explicit net7 and net8 targets.

Worth noting many orgs may not want 7.0 dependencies as its not long-term supported, unlike net6 & net8.

Upgrade testlib and codegen to net8 just to flush out any issues.

TODO: Assembly versions need updating for nuget publishing.