### PR TITLE
Allow Classes to be enumerated for IFC4, IFC4.3 specific schemas. Fix for #37

### DIFF
--- a/ids-lib/IfcSchema/SchemaInfo.cs
+++ b/ids-lib/IfcSchema/SchemaInfo.cs
@@ -552,24 +552,24 @@ namespace IdsLib.IfcSchema
         {
             if (schemaVersions.IsSingleSchema())
             {
-				var schema = GetSchemas(IfcSchemaVersions.IfcAllVersions).First();
+                var schema = GetSchemas(schemaVersions).First();
                 if (schema is null)
                     return Enumerable.Empty<string>();
                 var top = schema[topClass];
                 if (top is null)
                     return Enumerable.Empty<string>();
-				return top.MatchingConcreteClasses.Select(x=>x.Name);
-			}
+                return top.MatchingConcreteClasses.Select(x=>x.Name);
+            }
 
-			var schemas = GetSchemas(IfcSchemaVersions.IfcAllVersions);
+            var schemas = GetSchemas(IfcSchemaVersions.IfcAllVersions);
             List<string> ret = new();
-			foreach (var schema in schemas)
+            foreach (var schema in schemas)
             {
                 var top = schema[topClass];
                 if (top is null)
                     continue;
                 ret = ret.Union(top.MatchingConcreteClasses.Select(x => x.Name)).ToList();
-			}
+            }
             return ret;
         }
 

--- a/ids-tool.tests/IfcSchemaTests.cs
+++ b/ids-tool.tests/IfcSchemaTests.cs
@@ -109,7 +109,20 @@ public class IfcSchemaTests
 		
 	}
 
-	[Theory]
+    [Fact]
+    public void CanGetConcreteSubclassesForSpecificSchema()
+    {
+        // IFCCABLECARRIERSEGMENT is new in IFC4
+        var elements = SchemaInfo.GetConcreteClassesFrom("IFCCABLECARRIERSEGMENT", IfcSchemaVersions.Ifc4);
+        elements.Should().NotBeNull();
+        elements.Should().HaveCount(1);
+
+        elements = SchemaInfo.GetConcreteClassesFrom("IFCFACILITYPART", IfcSchemaVersions.Ifc4x3);
+        elements.Should().Contain("IfcRailwayPart");
+        elements.Should().HaveCount(5);
+    }
+
+        [Theory]
     [InlineData("IFCOBJECTDEFINITION", 194,366)]
     [InlineData("IFCWALL",2, 3)]
     [InlineData("IFCNOTEXISTING",-1, -1)]


### PR DESCRIPTION
We were ignoring the schema param being passed in, and falling back to IFC2x3