### PR TITLE
Fix for #39 where Type sub-classes not being offered as valid for a Pset unless explicitly referenced

### DIFF
--- a/ids-lib/IfcSchema/SchemaInfo.cs
+++ b/ids-lib/IfcSchema/SchemaInfo.cs
@@ -304,7 +304,7 @@ namespace IdsLib.IfcSchema
                         if (tp is not null && tp.RelationTypeClasses is not null)
                         {
                             typeObjects.AddRange(tp.RelationTypeClasses);
-                            // RelationTypeClasses only includes immediate ancestores, so we need to include all subClasses of any TypeObjects
+                            // RelationTypeClasses only includes immediate ancestors, so we need to include all subClasses of any TypeObjects
                             // as these also are valid for the propertySet
                             var subTypes = tp.RelationTypeClasses.SelectMany(typ => schema[typ]!.SubClasses.Select(s => s.Name)).Distinct();
                             if(subTypes.Any())

--- a/ids-lib/IfcSchema/SchemaInfo.cs
+++ b/ids-lib/IfcSchema/SchemaInfo.cs
@@ -302,7 +302,16 @@ namespace IdsLib.IfcSchema
                     {
                         var tp = schema[item];
                         if (tp is not null && tp.RelationTypeClasses is not null)
+                        {
                             typeObjects.AddRange(tp.RelationTypeClasses);
+                            // RelationTypeClasses only includes immediate ancestores, so we need to include all subClasses of any TypeObjects
+                            // as these also are valid for the propertySet
+                            var subTypes = tp.RelationTypeClasses.SelectMany(typ => schema[typ]!.SubClasses.Select(s => s.Name)).Distinct();
+                            if(subTypes.Any())
+                            {
+                                typeObjects.AddRange(subTypes);
+                            }
+                        }
                     }
                     if (typeObjects.Any())
                         thisPsetTypes = thisPsetTypes.ToList().Concat(typeObjects.Distinct()).ToList();

--- a/ids-lib/LibraryInformation.cs
+++ b/ids-lib/LibraryInformation.cs
@@ -26,5 +26,5 @@ public static class LibraryInformation
 	/// <summary>
 	/// Static field with hardcoded DLL version number. 
 	/// </summary>
-	public static string AssemblyVersion => "1.0.76";
+	public static string AssemblyVersion => "1.0.77";
 }

--- a/ids-lib/ids-lib.csproj
+++ b/ids-lib/ids-lib.csproj
@@ -20,7 +20,7 @@
 		<PackageReleaseNotes>First implementation.</PackageReleaseNotes>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<!-- Github actions are setup so that when this version is bumped the nuget package is uploaded -->
-		<AssemblyVersion>1.0.76</AssemblyVersion>
+		<AssemblyVersion>1.0.77</AssemblyVersion>
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/ids-tool.tests/IfcSchemaTests.cs
+++ b/ids-tool.tests/IfcSchemaTests.cs
@@ -216,5 +216,21 @@ public class IfcSchemaTests
     }
 
 
+    [Fact]
+    public void AllSubClassesOfTypesAreIncludedAsPossibleTypesForPropertySets()
+    {
+        var psets = new[] { "Pset_ManufacturerTypeInformation" };
+        var classes = SchemaInfo.PossibleTypesForPropertySets(IfcSchemaVersions.Ifc2x3, psets).Select(e=> e.ToUpperInvariant());
+
+        // Sanity checking
+        classes.Should().Contain("IFCWALL");
+        classes.Should().Contain("IFCWALLTYPE");
+        classes.Should().Contain("IFCDISTRIBUTIONCONTROLELEMENT");
+
+        // Bug - IFC2x3 Type Subtypes were not being returned: Issue #39
+        classes.Should().Contain("IFCACTUATORTYPE"); 
+        classes.Should().Contain("IFCAIRTERMINALTYPE");
+    }
+
 
 }

--- a/ids-tool.tests/IssueFiles/Issue 39 - IfcTypeObjects allowed.ids
+++ b/ids-tool.tests/IssueFiles/Issue 39 - IfcTypeObjects allowed.ids
@@ -4,11 +4,11 @@
   </info>
   <specifications>
     <specification ifcVersion="IFC2X3" name="IfcActuatorType.ModelLabel"
-                   description="Issue is that there's no IFCACTUATOR in IFC2x3 so we get a false 'Inconsistent Clauses' 201 error">
+                   description="Issue is that there's no IFCACTUATOR instance in IFC2x3 so we get a false 'Inconsistent Clauses' 201 error, since subClasses were not being considered">
       <applicability minOccurs="0" maxOccurs="unbounded">
         <entity>
           <name>
-            <simpleValue>IFCDISTRIBUTIONCONTROLELEMENTTYPE</simpleValue>
+            <simpleValue>IFCACTUATORTYPE</simpleValue>
           </name>
         </entity>
       </applicability>

--- a/ids-tool.tests/IssueFiles/Issue 39 - IfcTypeObjects allowed.ids
+++ b/ids-tool.tests/IssueFiles/Issue 39 - IfcTypeObjects allowed.ids
@@ -1,0 +1,27 @@
+﻿<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+  <info>
+    <title>Can select IfcTypeObjects that don't have equivalent IfcObject in IFC2x3</title>
+  </info>
+  <specifications>
+    <specification ifcVersion="IFC2X3" name="IfcActuatorType.ModelLabel"
+                   description="Issue is that there's no IFCACTUATOR in IFC2x3 so we get a false 'Inconsistent Clauses' 201 error">
+      <applicability minOccurs="0" maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCDISTRIBUTIONCONTROLELEMENTTYPE</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Pset_ManufacturerTypeInformation</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>ModelLabel</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/ids-tool.tests/IssueTests.cs
+++ b/ids-tool.tests/IssueTests.cs
@@ -59,5 +59,12 @@ namespace idsTool.tests
 			var f = new FileInfo("IssueFiles/Issue 30 - should return error.ids");
 			LoggerAndAuditHelpers.FullAudit(f, XunitOutputHelper, IdsLib.Audit.Status.IdsContentError, 2);
 		}
-	}
+
+        [Fact]
+        public void Issue_39_SubClassesOfObjectTypesAllowPsets()
+        {
+            var f = new FileInfo("IssueFiles/Issue 39 - IfcTypeObjects allowed.ids");
+            LoggerAndAuditHelpers.FullAudit(f, XunitOutputHelper, IdsLib.Audit.Status.Ok);
+        }
+    }
 }

--- a/ids-tool.tests/ids-tool.tests.csproj
+++ b/ids-tool.tests/ids-tool.tests.csproj
@@ -168,6 +168,9 @@
 		<None Update="IssueFiles\Issue 08 - Regex pattern.ids">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="IssueFiles\Issue 39 - IfcTypeObjects allowed.ids">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="IssueFiles\Issue 11 - IfcLogical.ids">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/ids-tool/ids-tool.csproj
+++ b/ids-tool/ids-tool.csproj
@@ -16,7 +16,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>IDS, buildingSmart</PackageTags>
 		<!-- Github actions are setup so that when this version is bumped the nuget package is uploaded -->
-		<AssemblyVersion>1.0.76</AssemblyVersion>
+		<AssemblyVersion>1.0.77</AssemblyVersion>
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>
 		<RepositoryUrl>https://github.com/buildingSMART/IDS-Audit-tool.git</RepositoryUrl>


### PR DESCRIPTION
Fix for #39

I chose a tactical fix vs changing the code generation to include SubClasses of RelatedTypes. Felt like lesser impact.